### PR TITLE
Fix bug that adds multiple deletion/insertion lines on 'remove_all_for_note' function

### DIFF
--- a/static/control.js
+++ b/static/control.js
@@ -131,16 +131,24 @@ const AlignmentManager = {
             }
         }
         
+        const pp_inserted = [];
+        const score_deleted = [];
         // Add indel rows only for notes that have no other matches
         for (const [pp, pt] of matches_to_remove) {
             const perfHasOtherMatches = this._has_other_matches(pp, "perf");
             const scoreHasOtherMatches = this._has_other_matches(pt, "score");
             
             if (!perfHasOtherMatches) {
-                this._add_insertion_indel(pp);
+                if (!pp_inserted.includes(pp)) {
+                    this._add_insertion_indel(pp);
+                    pp_inserted.push(pp);
+                }
             }
             if (!scoreHasOtherMatches) {
-                this._add_deletion_indel(pt);
+                if (!score_deleted.includes(pt)) {
+                    this._add_deletion_indel(pt);
+                    score_deleted.push(pt);
+                }
             }
         }
     },


### PR DESCRIPTION
### Fix duplicate deletion/insertion indel entries in the updated CSV when removing alignments involving notes with multiple associations.

Previously, if a single score note was aligned to multiple performance notes, removing all alignments for that score note would generate duplicate deletion entries — one for each aligned performance note. The same issue occurred in reverse for performance notes aligned to multiple score notes, resulting in duplicate insertion entries.

**Changes**

Updated AlignmentManager.remove_all_for_note to avoid adding duplicate indels for the same note during bulk alignment removal.

Specifically:

Before calling _add_deletion_indel for a score note, the function now checks whether a deletion indel has already been added for that note during the current removal operation.
Similarly, before calling _add_insertion_indel for a performance note, it checks whether an insertion indel has already been added.

This ensures that:

- Each score note produces at most one deletion entry.

- Each performance note produces at most one insertion entry.